### PR TITLE
cast pkt.time to float

### DIFF
--- a/src/scapy_tcp/tcp_stream.py
+++ b/src/scapy_tcp/tcp_stream.py
@@ -50,7 +50,7 @@ class TCPStream:
         self.time = pkt.time        
         self.tcp_state = TCPStateMachine(pkt)
         self.flows = self.tcp_state.flows
-        self.pkts = {self.time:pkt}
+        self.pkts = {float(self.time): pkt}
         self.ordered_pkts  = None
         self.last_time_written = 0.0
         self.pcap_file = None
@@ -87,7 +87,7 @@ class TCPStream:
     
     def add_pkt(self, pkt):
         is_closed = self.tcp_state.next_state(pkt)
-        self.pkts[pkt.time] = pkt
+        self.pkts[float(pkt.time)] = pkt
         self.last_time = pkt.time
         return is_closed
         


### PR DESCRIPTION
pkt.time if of type EDecimal which is not hashable and thou can not be used as dictionary key. We must cast pkt.time to a hashable type to be able to use is as dictionary key. We can cast it to a float.
More info on hashable: https://docs.python.org/3/reference/datamodel.html#object.__hash__